### PR TITLE
Add assertions to document critical assumptions

### DIFF
--- a/data/athena.txt
+++ b/data/athena.txt
@@ -2,3 +2,5 @@ T | 0 | new task
 T | 1 | this
 T | 1 | eat lunch
 D | 0 | event | 2024-01-01 0400
+T | 0 | h
+T | 0 | null

--- a/src/main/java/athena/Athena.java
+++ b/src/main/java/athena/Athena.java
@@ -23,6 +23,8 @@ public class Athena {
     }
 
     public String getResponse(String input) {
+        assert input != null : "Logic engine received a null input string";
+
         try {
             return executeCommand(input);
         } catch (AthenaException e) {
@@ -68,11 +70,15 @@ public class Athena {
     }
 
     private String handleList() {
-        if (tasks.getSize() == 0) return "Your list is currently empty, spartan.";
+        if (tasks.getSize() == 0) {
+            return "Your list is currently empty, spartan.";
+        }
         StringBuilder out = new StringBuilder("Here are the tasks in your list:\n");
         for (int i = 0; i < tasks.getSize(); i++) {
             out.append(i + 1).append(".").append(tasks.getTask(i));
-            if (i < tasks.getSize() - 1) out.append("\n");
+            if (i < tasks.getSize() - 1) {
+                out.append("\n");
+            }
         }
         return out.toString();
     }
@@ -126,12 +132,16 @@ public class Athena {
     private String handleFind(String input) throws AthenaException {
         String keyword = Parser.parseFindKeyword(input);
         ArrayList<Task> found = tasks.findTasks(keyword);
-        if (found.isEmpty()) return "No matching tasks found for: " + keyword;
+        if (found.isEmpty()) {
+            return "No matching tasks found for: " + keyword;
+        }
 
         StringBuilder result = new StringBuilder("Matching tasks found:\n");
         for (int i = 0; i < found.size(); i++) {
             result.append(i + 1).append(".").append(found.get(i));
-            if (i < found.size() - 1) result.append("\n");
+            if (i < found.size() - 1) {
+                result.append("\n");
+            }
         }
         return result.toString();
     }

--- a/src/main/java/athena/DialogBox.java
+++ b/src/main/java/athena/DialogBox.java
@@ -21,6 +21,8 @@ public class DialogBox extends HBox {
     private ImageView displayPicture;
 
     private DialogBox(String text, Image img) {
+        assert img != null : "Avatar image is missing for DialogBox";
+
         try {
             FXMLLoader fxmlLoader = new FXMLLoader(MainWindow.class.getResource("/view/DialogBox.fxml"));
             fxmlLoader.setController(this);

--- a/src/main/java/athena/MainWindow.java
+++ b/src/main/java/athena/MainWindow.java
@@ -33,6 +33,8 @@ public class MainWindow extends AnchorPane {
     }
 
     public void setAthena(Athena a) {
+        assert a != null : "Athena engine was not initialized correctly";
+
         athena = a;
         dialogContainer.getChildren().add(
                 DialogBox.getAthenaDialog("The phalanx is formed. Spartan, your orders?", athenaImage)
@@ -42,7 +44,12 @@ public class MainWindow extends AnchorPane {
     @FXML
     private void handleUserInput() {
         String input = userInput.getText();
+
+        assert input != null : "userInput TextField returned a null value";
+
         String response = athena.getResponse(input);
+
+        assert response != null : "Athena logic returned a null response";
 
         dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(input, userImage),

--- a/src/main/java/athena/Parser.java
+++ b/src/main/java/athena/Parser.java
@@ -12,6 +12,7 @@ public class Parser {
      * @return The first word of the input string.
      */
     public static String getCommandWord(String input) {
+        assert input != null : "Input to getCommandWord cannot be null";
         return input.trim().split(" ")[0];
     }
 
@@ -23,6 +24,8 @@ public class Parser {
      */
     public static int parseIndex(String input) {
         String[] parts = input.split(" ");
+        assert parts.length >= 2 : "parseIndex called on input without index argument";
+
         return Integer.parseInt(parts[1]) - 1;
     }
 
@@ -48,6 +51,8 @@ public class Parser {
      * @throws AthenaException If the /by keyword is missing or description is empty.
      */
     public static String[] parseDeadline(String input) throws AthenaException {
+        assert input.toLowerCase().startsWith("deadline") : "parseDeadline called on non-deadline command";
+
         int byIdx = input.indexOf(" /by ");
         if (byIdx == -1) {
             throw new AthenaException("A deadline must have a /by time.");

--- a/src/main/java/athena/Storage.java
+++ b/src/main/java/athena/Storage.java
@@ -24,6 +24,9 @@ public class Storage {
 
         try {
             List<String> lines = Files.readAllLines(Paths.get(filePath));
+
+            assert lines != null : "File reading returned a null list of lines";
+
             for (String line : lines) {
                 Task t = parseLineToTask(line);
                 if (t != null) {
@@ -38,7 +41,12 @@ public class Storage {
 
     private Task parseLineToTask(String line) {
         String[] p = line.split(" \\| ");
-        if (p.length < 3) return null;
+
+        if (p.length < 3) {
+            return null;
+        }
+
+        assert p.length >= 3 : "Logic error: p.length check failed to catch a short line";
 
         Task t;
         switch (p[0]) {

--- a/src/main/java/athena/TaskList.java
+++ b/src/main/java/athena/TaskList.java
@@ -21,14 +21,17 @@ public class TaskList {
     }
 
     public Task getTask(int index) {
+        assert index >= 0 && index < tasks.size() : "Index out of bounds in TaskList.getTask";
         return tasks.get(index);
     }
 
     public void add(Task t) {
+        assert t != null : "Cannot add a null task to TaskList";
         tasks.add(t);
     }
 
     public Task delete(int index) {
+        assert index >= 0 && index < tasks.size() : "Index out of bounds in TaskList.delete";
         return tasks.remove(index);
     }
 


### PR DESCRIPTION
Several parts of the code assume non-null inputs and valid internal state, but these assumptions are not explicitly documented or enforced.

This makes it harder to detect logic errors early and increases the risk of silent failures when assumptions are violated.

Let's add assertions at key points where critical assumptions are made, such as before parsing user input and before executing commands that depend on non-null data.

Using assertions is appropriate here because these conditions are expected to always hold during correct program execution and violations indicate programmer errors rather than user errors.